### PR TITLE
Update the addon to use the ActionButton API so that the button shows up...

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -130,11 +130,11 @@ function grenade() {
   }
 }
 
-ui.ActionButton({
-  id: 'tab-grenade1',
-  label: 'Tab Grenade',
-  icon: self.data.url('grenade-32.png'),
-  onClick: grenade
+require('sdk/ui/button/action').ActionButton({
+    id: 'tab-grenade1',
+    label: 'Tab Grenade',
+    icon: self.data.url('grenade-32.png'),
+    onClick: grenade
 });
 
 var { Hotkey } = require('sdk/hotkeys');


### PR DESCRIPTION
... in newer Firefox versions

The addon button doesn't show up in newer releases of Firefox at all. I have tried on Windows and Linux and I cannot still see the addon button to use it. See issue #11. I have updated the addon code to use the ActionButton API so that it works on newer Firefox versions.

Not sure how to keep the backward compatibility here. Please advise.