### PR TITLE
populate the index page when visited directly

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -166,20 +166,6 @@ function reloadTG(options) {
 }
 
 /**
- * In case of browser startup, we check if a tab grenade tab was loaded and
- * force it to reload and execute `runScript`. Otherwise it won't load the
- * necessary scripts.
- */
-exports.main = function(options) {
-  if (options.loadReason === 'startup') {
-    if (!reloadTG()) {
-      console.info('Didn\'t find a tab on first attempt; retrying.');
-      require('sdk/timers').setTimeout(reloadTG, 5);
-    }
-  }
-};
-
-/**
  * When indexURL is opened manually (from a bookmark or set as homepage),
  * populate the otherwise blank page with a listing of all grenaded tabs.
  */

--- a/lib/main.js
+++ b/lib/main.js
@@ -179,3 +179,13 @@ exports.main = function(options) {
   }
 };
 
+/**
+ * When indexURL is opened manually (from a bookmark or set as homepage),
+ * populate the otherwise blank page with a listing of all grenaded tabs.
+ */
+require('sdk/page-mod').PageMod({
+  include: indexURL,
+  onAttach: function(worker) {
+    runScript(worker.tab);
+  }
+});


### PR DESCRIPTION
When indexURL is opened manually (from a bookmark or set as homepage),
populate the otherwise blank page with a listing of all grenaded tabs.

This allows users to bookmark the index page and/or set it as homepage.

See also https://github.com/sergi/tabgrenade/issues/19
